### PR TITLE
feat: one topic per IMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project contains a ROS2 driver for the Xsens MTw Awinda system sensors.
 - Custom .yaml config file
 - Node control via terminal key presses or ROS2 services
 - Simultaneous orientation visualization in RViz for multiple IMUs
+- One-topic-for-all or one-topic-per-imu
 
 ### Hardware
 
@@ -47,7 +48,7 @@ This project contains a ROS2 driver for the Xsens MTw Awinda system sensors.
 - [Ubuntu Linux](https://www.releases.ubuntu.com/)
 - [ROS2](https://docs.ros.org/)
 
-Tested with Ubuntu 22.04 (ROS2 Humble) and 24.04 (ROS2 Jazzy).
+Tested with Ubuntu 22.04 (ROS2 Humble, ROS2 Rolling) and 24.04 (ROS2 Jazzy).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ source install/setup.bash
 
 ### Xsens MTw Manager
 
-By default, the Xsens MTw Manager node publishes a separate ROS 2 topic named `/xsens_imu_data_<IMU ID>` for each IMU sensor. The topic name, an optional combined topic for all IMU sensors, and other parameters can be configured in the `/config/params.yaml` file or at the top of the `xsens_mtw_manager.cpp` file. See [Custom parameters](#custom-parameters) for more information.
+By default, the Xsens MTw Manager node publishes all sensor data into the `/xsens_imu_data` ROS2 topic. The topic name, an option to enable one topic per IMU sensor, and other parameters can be configured in the `/config/params.yaml` or at the top of the `xsens_mtw_manager.cpp`. See [Custom parameters](#custom-parameters) for more information.
 
-ROS2 timestamps are used to record the time at which data is received. If a data packet is lost, the last available data will be used. The recorded data is saved in a `.csv` file with multi-indexing (header of 3). This file will include the ROS2 timestamps with the received MTw orientation, angular velocity, linear acceleration and the magnetic field. The recorded data is saved in the same directory where the node is started.
+ROS2 timestamps are used to record the time at which data is received. If a data packet is lost, the last available data will be used. The recorded data is saved in a `.csv` file with multi-indexing (header of 3). This file will include the ROS2 timestamps with the received MTw orientation, angular velocity, linear acceleration and the magnetic field. The recorded data is saved in the same directory where the node is started. Currently, setting `one_topic_per_imu` to `true` will cause the recording feature of the node to apply only the latest timestamp, as if data from all IMUs were published simultaneously.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ source install/setup.bash
 
 ### Xsens MTw Manager
 
-By default, the Xsens MTw Manager node publishes all sensor data into the `/xsens_imu_data` ROS2 topic. The topic name and other parameters can be adjusted in the `/config/params.yaml` file. See [Custom parameters](#custom-parameters) for more information.
+By default, the Xsens MTw Manager node publishes a separate ROS 2 topic named `/xsens_imu_data_<IMU ID>` for each IMU sensor. The topic name, an optional combined topic for all IMU sensors, and other parameters can be configured in the `/config/params.yaml` file or at the top of the `xsens_mtw_manager.cpp` file. See [Custom parameters](#custom-parameters) for more information.
 
 ROS2 timestamps are used to record the time at which data is received. If a data packet is lost, the last available data will be used. The recorded data is saved in a `.csv` file with multi-indexing (header of 3). This file will include the ROS2 timestamps with the received MTw orientation, angular velocity, linear acceleration and the magnetic field. The recorded data is saved in the same directory where the node is started.
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ ros2 run xsens_mtw_driver xsens_mtw_manager --ros-args --params-file </path/to/p
 ### Xsens MTw Visualization
 
 The `xsens_mtw_visualization` node publishes the IMU orientations in the `/tf` ROS2 topic for visualization purposes in RViz. Make sure to
-have the TF display added in RViz. Also see [Xsens MTw Awinda IMU Coordinate System](#xsens-mtw-awinda-imu-coordinate-system) to know which way the IMUs are oriented.
+have the TF display added in RViz. Also see [Xsens MTw Awinda IMU Coordinate System](#xsens-mtw-coordinate-system) to know which way the IMUs are oriented.
 
 Using `xsens_mtw_visualization` without any config, will publish the TFs of all IMUs next to each other. Using the launch file will load `/config/imu_mapping.yaml`. This is only used for a specific IMU setup. The idea behind it is to move the IMU orientations into a more visually comprehensible position. The amount of IMUs can be adjusted in the `.yaml` file and the positions inside the `xsens_mtw_visualization.cpp` file.
 

--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ The `/config/params.yaml` can be used to easily set the desired parameters. Make
 
 If the `ros2_rate` is larger than the `imu_rate`, the node will upsample the IMU data by always using the last available data until the next data is received. The `imu_rate` is the maximum rate the IMUs can send data. Make sure to follow the [supported sensor update rates](#supported-sensor-update-rates-for-the-xsens-mtw-awinda-system).
 
-| Parameter           | Description                                  |
-|---------------------|----------------------------------------------|
-| topic_name          | ROS2 topic name for published data           |
-| ros2_rate           | ROS2 data publish rate                       |
-| imu_rate            | IMU data update rate                         |
-| imu_reset_on_record | Reset IMU orientation on record start        |
-| use_magnetometer    | Use Magnetometer data to update orientations |
+| Parameter           | Description                                            |
+|---------------------|--------------------------------------------------------|
+| one_topic_per_imu   | Switch between one-topic-for-all and one-topic-per-imu |
+| topic_name          | ROS2 topic name for published data                     |
+| ros2_rate           | ROS2 data publish rate                                 |
+| imu_rate            | IMU data update rate                                   |
+| imu_reset_on_record | Reset IMU orientation on record start                  |
+| use_magnetometer    | Use Magnetometer data to update orientations           |
 
 #### No keyboard inputs for launch files
 
@@ -139,7 +140,8 @@ ros2 run xsens_mtw_driver xsens_mtw_manager --ros-args --params-file </path/to/p
 
 ### Xsens MTw Visualization
 
-The `xsens_mtw_visualization` node publishes the IMU orientations in the `/tf` ROS2 topic for visualization purposes in RViz. Make sure to have the TF display added in RViz. Also see [Xsens MTw Awinda IMU Coordinate System](#xsens-mtw-awinda-imu-coordinate-system) to know which way the IMUs are oriented.
+The `xsens_mtw_visualization` node publishes the IMU orientations in the `/tf` ROS2 topic for visualization purposes in RViz. Make sure to|---------------------|--------------------------------------------------------|
+ have the TF display added in RViz. Also see [Xsens MTw Awinda IMU Coordinate System](#xsens-mtw-awinda-imu-coordinate-system) to know which way the IMUs are oriented.
 
 Using `xsens_mtw_visualization` without any config, will publish the TFs of all IMUs next to each other. Using the launch file will load `/config/imu_mapping.yaml`. This is only used for a specific IMU setup. The idea behind it is to move the IMU orientations into a more visually comprehensible position. The amount of IMUs can be adjusted in the `.yaml` file and the positions inside the `xsens_mtw_visualization.cpp` file.
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ ros2 run xsens_mtw_driver xsens_mtw_manager --ros-args --params-file </path/to/p
 
 ### Xsens MTw Visualization
 
-The `xsens_mtw_visualization` node publishes the IMU orientations in the `/tf` ROS2 topic for visualization purposes in RViz. Make sure to|---------------------|--------------------------------------------------------|
- have the TF display added in RViz. Also see [Xsens MTw Awinda IMU Coordinate System](#xsens-mtw-awinda-imu-coordinate-system) to know which way the IMUs are oriented.
+The `xsens_mtw_visualization` node publishes the IMU orientations in the `/tf` ROS2 topic for visualization purposes in RViz. Make sure to
+have the TF display added in RViz. Also see [Xsens MTw Awinda IMU Coordinate System](#xsens-mtw-awinda-imu-coordinate-system) to know which way the IMUs are oriented.
 
 Using `xsens_mtw_visualization` without any config, will publish the TFs of all IMUs next to each other. Using the launch file will load `/config/imu_mapping.yaml`. This is only used for a specific IMU setup. The idea behind it is to move the IMU orientations into a more visually comprehensible position. The amount of IMUs can be adjusted in the `.yaml` file and the positions inside the `xsens_mtw_visualization.cpp` file.
 

--- a/interfaces/imu_msgs/CMakeLists.txt
+++ b/interfaces/imu_msgs/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/IMUData.msg"
+  "msg/IMUDataSingle.msg"
   "msg/IMUDataArray.msg"
   "msg/Quaternion.msg"
   DEPENDENCIES geometry_msgs std_msgs

--- a/interfaces/imu_msgs/msg/IMUDataSingle.msg
+++ b/interfaces/imu_msgs/msg/IMUDataSingle.msg
@@ -1,0 +1,2 @@
+uint64 timestamp
+imu_msgs/IMUData imu_data

--- a/interfaces/imu_msgs/package.xml
+++ b/interfaces/imu_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>imu_msgs</name>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <description>Custom messages for IMU data using the ROS2 xsens_mtw_driver package.</description>
   <maintainer email="sommler@live.de">Kevin Sommler</maintainer>
   <license>MIT</license>

--- a/xsens_mtw_driver/config/params.yaml
+++ b/xsens_mtw_driver/config/params.yaml
@@ -1,6 +1,7 @@
 xsens_mtw_manager:
   ros__parameters:
-    topic_name: "xsens_imu_data"    # string
+    one_topic_per_imu: true         # bool    One topic for all the IMUs or one topic per IMU
+    topic_name: "xsens_imu_data"    # string  Topic name for the mono topic or prefix of the topic name for one topic per IMU
     ros2_rate: 100                  # int     ROS2 data publish rate
     imu_rate: 100                   # int     see supported update rates [120, 100, 80, 60, 40]
     imu_reset_on_record: true       # bool    reset IMU orientation on record start

--- a/xsens_mtw_driver/config/params.yaml
+++ b/xsens_mtw_driver/config/params.yaml
@@ -1,6 +1,6 @@
 xsens_mtw_manager:
   ros__parameters:
-    one_topic_per_imu: true         # bool    One topic for all the IMUs or one topic per IMU
+    one_topic_per_imu: false        # bool    One topic for all the IMUs or one topic per IMU
     topic_name: "xsens_imu_data"    # string  Topic name for the mono topic or prefix of the topic name for one topic per IMU
     ros2_rate: 100                  # int     ROS2 data publish rate
     imu_rate: 100                   # int     see supported update rates [120, 100, 80, 60, 40]

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -14,6 +14,7 @@
 // Custom ROS2 messages
 #include "imu_msgs/msg/imu_data.hpp"
 #include "imu_msgs/msg/imu_data_array.hpp"
+#include "imu_msgs/msg/imu_data_single.hpp"
 #include "imu_msgs/msg/quaternion.hpp"
 
 // Custom ROS2

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -86,6 +86,7 @@ private:
 
     // ROS2 Parameters
     std::string m_topicName;
+    bool m_oneTopicPerImu;
     int m_ros2Rate;
     int m_imuRate;
     int m_radioChannel;
@@ -98,6 +99,8 @@ private:
 
     // ROS2 Publisher
     rclcpp::Publisher<imu_msgs::msg::IMUDataArray>::SharedPtr m_imuPublisher;
+    std::vector<std::shared_ptr<rclcpp::Publisher<imu_msgs::msg::IMUDataSingle, std::allocator<void>>>> m_imuPublishers;
+
     int64_t m_timestamp;
 
     // ROS2 Services

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -81,6 +81,7 @@ private:
     std::ofstream m_file;
     std::vector<int> m_dataTracker;
     int m_maxDataSkip;
+    int64_t m_timestamp;
     bool m_waitForConnections;
     bool m_keyInterrupt;
     bool m_isHeaderWritten;
@@ -101,8 +102,6 @@ private:
     // ROS2 Publisher
     rclcpp::Publisher<imu_msgs::msg::IMUDataArray>::SharedPtr m_imuPublisher;
     std::vector<std::shared_ptr<rclcpp::Publisher<imu_msgs::msg::IMUDataSingle, std::allocator<void>>>> m_imuPublishers;
-
-    int64_t m_timestamp;
 
     // ROS2 Services
     rclcpp::Service<xsrvs::Trigger>::SharedPtr m_statusService;

--- a/xsens_mtw_driver/package.xml
+++ b/xsens_mtw_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>xsens_mtw_driver</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>A driver for using the Xsens MTw Awinda system within ROS2.</description>
   <maintainer email="sommler@live.de">Kevin Sommler</maintainer>
   <license>MIT</license>

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -13,7 +13,7 @@ XsensManager::XsensManager(const std::string & name)
 {
     // --------------------------------------------------------------------
     // ROS2 PARAMETERS
-    this->declare_parameter("one_topic_per_imu", true);
+    this->declare_parameter("one_topic_per_imu", false);
     m_oneTopicPerImu = this->get_parameter("one_topic_per_imu").as_bool();
 
     this->declare_parameter("topic_name", "xsens_imu_data");

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -284,8 +284,8 @@ void XsensManager::completeInitialization()
     if (m_oneTopicPerImu){
         // One-topic-per-imu
         for (size_t i = 0; i < m_connectedMTWCount; ++i)
-		{
-			std::string mtwID = m_mtwDeviceIds[i].toString().toStdString();
+        {
+            std::string mtwID = m_mtwDeviceIds[i].toString().toStdString();
 			auto imu_pub = this->create_publisher<imu_msgs::msg::IMUDataSingle>(m_topicName + mtwID, 10);
 			m_imuPublishers.push_back(imu_pub);
 		}

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -404,7 +404,6 @@ void XsensManager::publishDataCallback()
 
             imu_data_single_msg.imu_data = m_imuDataMsg[i];
             
-            m_timestamp = this->now().nanoseconds();
             imu_data_single_msg.timestamp = m_timestamp;
 
             m_imuPublishers[i]->publish(imu_data_single_msg);

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -386,7 +386,8 @@ void XsensManager::publishDataCallback()
         {
             m_vqfFilters[i].update(gyr, acc, mag);
             m_vqfFilters[i].getQuat9D(quat);
-        }m_timestamp = this->now().nanoseconds();
+        }
+        m_timestamp = this->now().nanoseconds();
 
         // Update orientation quaternion in message
         m_imuDataMsg[i].orientation.w = quat[0];

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -286,7 +286,7 @@ void XsensManager::completeInitialization()
         for (size_t i = 0; i < m_connectedMTWCount; ++i)
         {
             std::string mtwID = m_mtwDeviceIds[i].toString().toStdString();
-			auto imu_pub = this->create_publisher<imu_msgs::msg::IMUDataSingle>(m_topicName + mtwID, 10);
+			auto imu_pub = this->create_publisher<imu_msgs::msg::IMUDataSingle>(m_topicName + "_" + mtwID, 10);
 			m_imuPublishers.push_back(imu_pub);
 		}
     } else {


### PR DESCRIPTION
# Description

In previous version of the package (`xsens_mtw_driver-release`), one topic per IMU was created.
In the current version, only one topic is created for all the IMUs.
This PR add an option to switch between one-topic-for-all and one-topic-per-imu

Close #3 

## Changes
- Adding a new message `IMUDataSingle` to represent one IMU
- Adding a parameter to switch between the two modes. When using the one-topic-per-imu, the parameter `topic_name` will be the prefix of the topic and the ID of the IMU will be appended.
- Implementing the logic for one-topic-per-imu
- Updating the README with information

## Tests
Tested with 2 IMUs

### No errors in the command line
<img width="957" height="811" alt="screenshot_20250723_093751" src="https://github.com/user-attachments/assets/ddebda94-4cca-4c18-920d-c064089be902" />

### rqt_graph
<img width="1083" height="495" alt="screenshot_20250723_093814" src="https://github.com/user-attachments/assets/8be4eaff-6e24-4b62-bd47-ae8cd60971e8" />

### plotjuggler
<img width="593" height="467" alt="screenshot_20250723_093730" src="https://github.com/user-attachments/assets/c4556bd7-738b-4500-8590-628b8df2e96c" />
<img width="1256" height="868" alt="screenshot_20250723_093741" src="https://github.com/user-attachments/assets/27123ea2-5df6-40ba-914b-bb437b7b4bc6" />

You can notice the timestamps are different (due to having sometime between the two publication).

