### PR TITLE
feat: basic sync IN

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,30 +118,30 @@ If the `ros2_rate` is larger than the `imu_rate`, the node will upsample the IMU
 | imu_reset_on_record     | Reset IMU orientation on record start                  |
 | radio_channel           | Radio channel to use (11 to 25)                        |
 | use_magnetometer        | Use Magnetometer data to update orientations           |
-| use_synchronisation     | Enable Sync functionality                              |
-| synchronisation_topic   | Topic name for synchronisation messages               |
-| synchronisation_line    | Select the synchronisation line (1 or 2)              |
+| use_synchronization     | Enable Sync functionality                              |
+| synchronization_topic   | Topic name for synchronization messages               |
+| synchronization_line    | Select the synchronization line (1 or 2)              |
 
-#### Synchronisation
+#### synchronization
 
-The Xsens MTw driver supports synchronisation functionality through external trigger signals. This feature allows you to synchronize IMU data collection with external events or other sensor systems. Only external triggers going into the base station are supported for now.
+The Xsens MTw driver supports synchronization functionality through external trigger signals. This feature allows you to synchronize IMU data collection with external events or other sensor systems. Only external triggers going into the base station are supported for now.
 
 **Requirements:**
-- Requires an **Xsens Awinda XStation** (master device) to enable synchronisation functionality
-- External trigger signal connected to one of the synchronisation input lines
+- Requires an **Xsens Awinda XStation** (master device) to enable synchronization functionality
+- External trigger signal connected to one of the synchronization input lines
 
 **How it works:**
-- When `use_synchronisation` is enabled, the driver configures the Awinda XStation to listen for trigger signals on the specified synchronisation line (1 or 2)
+- When `use_synchronization` is enabled, the driver configures the Awinda XStation to listen for trigger signals on the specified synchronization line (1 or 2)
 - The system is set to trigger on rising edge signals with no skip factor or offset
 - When a trigger event is detected, the driver publishes the trigger timestamp to the specified ROS2 topic
 - The trigger timestamp is extracted from the IMU data packets and published as an `std_msgs::msg::Int64` message
 
 **Configuration:**
-- `use_synchronisation`: Set to `true` to enable sync functionality
-- `synchronisation_topic`: ROS2 topic name where trigger timestamps will be published (default: `"xsens_sync"`)
-- `synchronisation_line`: Select which sync input line to use - either `1` or `2` (default: `1`)
+- `use_synchronization`: Set to `true` to enable sync functionality
+- `synchronization_topic`: ROS2 topic name where trigger timestamps will be published (default: `"xsens_sync"`)
+- `synchronization_line`: Select which sync input line to use - either `1` or `2` (default: `1`)
 
-**Note:** If the Awinda XStation is not detected or sync configuration fails, synchronisation will be disabled and an error message will be logged.
+**Note:** If the Awinda XStation is not detected or sync configuration fails, synchronization will be disabled and an error message will be logged.
 
 #### No keyboard inputs for launch files
 

--- a/README.md
+++ b/README.md
@@ -109,39 +109,42 @@ The `/config/params.yaml` can be used to easily set the desired parameters. Make
 
 If the `ros2_rate` is larger than the `imu_rate`, the node will upsample the IMU data by always using the last available data until the next data is received. The `imu_rate` is the maximum rate the IMUs can send data. Make sure to follow the [supported sensor update rates](#supported-sensor-update-rates-for-the-xsens-mtw-awinda-system).
 
-| Parameter               | Description                                            |
-|-------------------------|--------------------------------------------------------|
-| one_topic_per_imu       | Switch between one-topic-for-all and one-topic-per-imu |
-| mtw_topic_name          | ROS2 topic name or prefix for published data           |
-| ros2_rate               | ROS2 data publish rate                                 |
-| imu_rate                | IMU data update rate                                   |
-| imu_reset_on_record     | Reset IMU orientation on record start                  |
-| radio_channel           | Radio channel to use (11 to 25)                        |
-| use_magnetometer        | Use Magnetometer data to update orientations           |
-| use_synchronization     | Enable Sync functionality                              |
-| synchronization_topic   | Topic name for synchronization messages               |
-| synchronization_line    | Select the synchronization line (1 or 2)              |
+| Parameter               | Description                                               |
+|-------------------------|-----------------------------------------------------------|
+| one_topic_per_imu       | Switch between one-topic-for-all and one-topic-per-imu    |
+| mtw_topic_name          | ROS2 topic name or prefix for published data              |
+| ros2_rate               | ROS2 data publish rate                                    |
+| imu_rate                | IMU data update rate                                      |
+| imu_reset_on_record     | Reset IMU orientation on record start                     |
+| radio_channel           | Radio channel to use (11 to 25)                           |
+| use_magnetometer        | Use Magnetometer data to update orientations              |
+| use_synchronization     | Enable Sync functionality                                 |
+| synchronization_topic   | Topic name for synchronization messages                   |
+| synchronization_line    | Select the Awinda Station synchronization line (1 or 2)   |
 
-#### synchronization
+#### Synchronization
 
 The Xsens MTw driver supports synchronization functionality through external trigger signals. This feature allows you to synchronize IMU data collection with external events or other sensor systems. Only external triggers going into the base station are supported for now.
 
-**Requirements:**
-- Requires an **Xsens Awinda XStation** (master device) to enable synchronization functionality
+##### Requirements
+
+- Requires an **Xsens Awinda Station** (master device) to enable synchronization functionality
 - External trigger signal connected to one of the synchronization input lines
 
-**How it works:**
-- When `use_synchronization` is enabled, the driver configures the Awinda XStation to listen for trigger signals on the specified synchronization line (1 or 2)
+##### How it works
+
+- When `use_synchronization` is enabled, the driver configures the Awinda Station to listen for trigger signals on the specified synchronization line (1 or 2)
 - The system is set to trigger on rising edge signals with no skip factor or offset
 - When a trigger event is detected, the driver publishes the trigger timestamp to the specified ROS2 topic
 - The trigger timestamp is extracted from the IMU data packets and published as an `std_msgs::msg::Int64` message
 
-**Configuration:**
+##### Configuration
+
 - `use_synchronization`: Set to `true` to enable sync functionality
 - `synchronization_topic`: ROS2 topic name where trigger timestamps will be published (default: `"xsens_sync"`)
 - `synchronization_line`: Select which sync input line to use - either `1` or `2` (default: `1`)
 
-**Note:** If the Awinda XStation is not detected or sync configuration fails, synchronization will be disabled and an error message will be logged.
+**Note:** If the Awinda Station is not detected or sync configuration fails, synchronization will be disabled and an error message will be logged.
 
 #### No keyboard inputs for launch files
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This project contains a ROS2 driver for the Xsens MTw Awinda system sensors.
 - Node control via terminal key presses or ROS2 services
 - Simultaneous orientation visualization in RViz for multiple IMUs
 - One-topic-for-all or one-topic-per-imu
+- Sync In support
 
 ### Hardware
 
@@ -108,15 +109,39 @@ The `/config/params.yaml` can be used to easily set the desired parameters. Make
 
 If the `ros2_rate` is larger than the `imu_rate`, the node will upsample the IMU data by always using the last available data until the next data is received. The `imu_rate` is the maximum rate the IMUs can send data. Make sure to follow the [supported sensor update rates](#supported-sensor-update-rates-for-the-xsens-mtw-awinda-system).
 
-| Parameter           | Description                                            |
-|---------------------|--------------------------------------------------------|
-| one_topic_per_imu   | Switch between one-topic-for-all and one-topic-per-imu |
-| mtw_topic_name      | ROS2 topic name or prefix for published data           |
-| ros2_rate           | ROS2 data publish rate                                 |
-| imu_rate            | IMU data update rate                                   |
-| imu_reset_on_record | Reset IMU orientation on record start                  |
-| radio_channel       | Radio channel to use (11 to 25)                        |
-| use_magnetometer    | Use Magnetometer data to update orientations           |
+| Parameter               | Description                                            |
+|-------------------------|--------------------------------------------------------|
+| one_topic_per_imu       | Switch between one-topic-for-all and one-topic-per-imu |
+| mtw_topic_name          | ROS2 topic name or prefix for published data           |
+| ros2_rate               | ROS2 data publish rate                                 |
+| imu_rate                | IMU data update rate                                   |
+| imu_reset_on_record     | Reset IMU orientation on record start                  |
+| radio_channel           | Radio channel to use (11 to 25)                        |
+| use_magnetometer        | Use Magnetometer data to update orientations           |
+| use_synchronisation     | Enable Sync functionality                              |
+| synchronisation_topic   | Topic name for synchronisation messages               |
+| synchronisation_line    | Select the synchronisation line (1 or 2)              |
+
+#### Synchronisation
+
+The Xsens MTw driver supports synchronisation functionality through external trigger signals. This feature allows you to synchronize IMU data collection with external events or other sensor systems. Only external triggers going into the base station are supported for now.
+
+**Requirements:**
+- Requires an **Xsens Awinda XStation** (master device) to enable synchronisation functionality
+- External trigger signal connected to one of the synchronisation input lines
+
+**How it works:**
+- When `use_synchronisation` is enabled, the driver configures the Awinda XStation to listen for trigger signals on the specified synchronisation line (1 or 2)
+- The system is set to trigger on rising edge signals with no skip factor or offset
+- When a trigger event is detected, the driver publishes the trigger timestamp to the specified ROS2 topic
+- The trigger timestamp is extracted from the IMU data packets and published as an `std_msgs::msg::Int64` message
+
+**Configuration:**
+- `use_synchronisation`: Set to `true` to enable sync functionality
+- `synchronisation_topic`: ROS2 topic name where trigger timestamps will be published (default: `"xsens_sync"`)
+- `synchronisation_line`: Select which sync input line to use - either `1` or `2` (default: `1`)
+
+**Note:** If the Awinda XStation is not detected or sync configuration fails, synchronisation will be disabled and an error message will be logged.
 
 #### No keyboard inputs for launch files
 

--- a/xsens_mtw_driver/config/params.yaml
+++ b/xsens_mtw_driver/config/params.yaml
@@ -11,9 +11,9 @@ xsens_mtw_manager:
     radio_channel: 25                   # int     range: 11 to 25
     use_magnetometer: false             # bool    for quaternion orientation calculation
 
-    use_synchronisation: true           # bool    Use synchronisation with the Xsens MTw Manager
-    synchronisation_topic: "xsens_sync" # string  Topic name for synchronisation messages
-    synchronisation_line: 1             # int     Select the sychronisation line (1 or 2)
+    use_synchronization: true           # bool    Use synchronization with the Xsens MTw Manager
+    synchronization_topic: "xsens_sync" # string  Topic name for synchronization messages
+    synchronization_line: 1             # int     Select the sychronisation line (1 or 2)
 
 xsens_mtw_visualization:
   ros__parameters:

--- a/xsens_mtw_driver/config/params.yaml
+++ b/xsens_mtw_driver/config/params.yaml
@@ -1,21 +1,24 @@
 /**:
   ros__parameters:
-    one_topic_per_imu: true            # bool    publish one topic per IMU or one mono topic
-    mtw_topic_name: "xsens_imu_data"   # string  Topic name for the mono topic or prefix of the topic name for one topic per IMU
+    one_topic_per_imu: true             # bool    publish one topic per IMU or one mono topic
+    mtw_topic_name: "xsens_imu_data"    # string  Topic name for the mono topic or prefix of the topic name for one topic per IMU
 
 xsens_mtw_manager:
   ros__parameters:
-    ros2_rate: 100                     # int     ROS2 data publish rate
-    imu_rate: 100                      # int     see supported update rates [120, 100, 80, 60, 40]
-    imu_reset_on_record: true          # bool    reset IMU orientation on record start
-    radio_channel: 25                  # int     range: 11 to 25
-    use_magnetometer: false            # bool    for quaternion orientation calculation
+    ros2_rate: 100                      # int     ROS2 data publish rate
+    imu_rate: 100                       # int     see supported update rates [120, 100, 80, 60, 40]
+    imu_reset_on_record: true           # bool    reset IMU orientation on record start
+    radio_channel: 25                   # int     range: 11 to 25
+    use_magnetometer: false             # bool    for quaternion orientation calculation
+
+    use_synchronisation: true           # bool    use synchronisation with the Xsens MTw Manager
+    synchronisation_topic: "xsens_sync" # string  topic name for synchronisation messages
 
 xsens_mtw_visualization:
   ros__parameters:
-    imu_spacing: 0.5                   # float   spacing between IMUs in meters
-    use_imu_mapping: false             # bool    use the IMU mapping to publish the TFs in a more comprehensible way
-    imu_prefix: "00B483"               # string  prefix of the IMU IDs (e.g. "00B483"), only needed if imu mapping is enabled
+    imu_spacing: 0.5                    # float   spacing between IMUs in meters
+    use_imu_mapping: false              # bool    use the IMU mapping to publish the TFs in a more comprehensible way
+    imu_prefix: "00B483"                # string  prefix of the IMU IDs (e.g. "00B483"), only needed if imu mapping is enabled
     imu_mapping:
       [
         "A1", "torso_imu",

--- a/xsens_mtw_driver/config/params.yaml
+++ b/xsens_mtw_driver/config/params.yaml
@@ -13,7 +13,7 @@ xsens_mtw_manager:
 
     use_synchronization: true           # bool    Use synchronization with the Xsens MTw Manager
     synchronization_topic: "xsens_sync" # string  Topic name for synchronization messages
-    synchronization_line: 1             # int     Select the sychronisation line (1 or 2)
+    synchronization_line: 1             # int     Select the synchronization line (1 or 2)
 
 xsens_mtw_visualization:
   ros__parameters:

--- a/xsens_mtw_driver/config/params.yaml
+++ b/xsens_mtw_driver/config/params.yaml
@@ -11,8 +11,9 @@ xsens_mtw_manager:
     radio_channel: 25                   # int     range: 11 to 25
     use_magnetometer: false             # bool    for quaternion orientation calculation
 
-    use_synchronisation: true           # bool    use synchronisation with the Xsens MTw Manager
-    synchronisation_topic: "xsens_sync" # string  topic name for synchronisation messages
+    use_synchronisation: true           # bool    Use synchronisation with the Xsens MTw Manager
+    synchronisation_topic: "xsens_sync" # string  Topic name for synchronisation messages
+    synchronisation_line: 1             # int     Select the sychronisation line (1 or 2)
 
 xsens_mtw_visualization:
   ros__parameters:

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -14,7 +14,6 @@
 // ROS2 messages
 #include "std_msgs/msg/int64.hpp"
 
-
 // Custom ROS2 messages
 #include "imu_msgs/msg/imu_data.hpp"
 #include "imu_msgs/msg/imu_data_array.hpp"
@@ -81,32 +80,31 @@ public:
 
 private:
     HardwareStatus m_status;
-    std::string m_fileName;
-    std::ofstream m_file;
-    std::vector<int> m_dataTracker;
     int m_maxDataSkip;
     int64_t m_timestamp;
     bool m_waitForConnections;
     bool m_keyInterrupt;
     bool m_isHeaderWritten;
+    std::ofstream m_file;
+    std::string m_fileName;
+    std::vector<int> m_dataTracker;
 
-    // synchronization
+    // Synchronization
     bool m_syncSuccessful;
     XsSyncLine m_line;
     XsDataIdentifier m_lineDateIdentifier;
 
     // ROS2 Parameters
-    std::string m_mtwTopicName;
-    bool m_oneTopicPerImu;
     int m_ros2Rate;
     int m_imuRate;
     int m_radioChannel;
+    int m_syncLine;
+    bool m_oneTopicPerImu;
     bool m_imuResetOnRecord;
     bool m_useMagnetometer;
-
-    bool m_usesynchronization;
+    bool m_useSynchronization;
+    std::string m_mtwTopicName;
     std::string m_syncTopicName;
-    int m_syncLine;
 
     // ROS2 Callbacks
     rclcpp::TimerBase::SharedPtr m_connectTimer;

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -89,7 +89,11 @@ private:
     bool m_waitForConnections;
     bool m_keyInterrupt;
     bool m_isHeaderWritten;
+
+    // Synchronisation
     bool m_syncSuccessful;
+    XsSyncLine m_line;
+    XsDataIdentifier m_lineDateIdentifier;
 
     // ROS2 Parameters
     std::string m_mtwTopicName;
@@ -102,6 +106,7 @@ private:
 
     bool m_useSynchronisation;
     std::string m_syncTopicName;
+    int m_syncLine;
 
     // ROS2 Callbacks
     rclcpp::TimerBase::SharedPtr m_connectTimer;

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -90,7 +90,7 @@ private:
     bool m_keyInterrupt;
     bool m_isHeaderWritten;
 
-    // Synchronisation
+    // synchronization
     bool m_syncSuccessful;
     XsSyncLine m_line;
     XsDataIdentifier m_lineDateIdentifier;
@@ -104,7 +104,7 @@ private:
     bool m_imuResetOnRecord;
     bool m_useMagnetometer;
 
-    bool m_useSynchronisation;
+    bool m_usesynchronization;
     std::string m_syncTopicName;
     int m_syncLine;
 
@@ -116,7 +116,7 @@ private:
     rclcpp::Publisher<imu_msgs::msg::IMUDataArray>::SharedPtr m_imuPublisher;
     std::vector<rclcpp::Publisher<imu_msgs::msg::IMUDataSingle>::SharedPtr> m_imuPublishers;
     rclcpp::Publisher<std_msgs::msg::Int64>::SharedPtr m_syncPublisher;
-    
+
     // ROS2 Services
     rclcpp::Service<xsrvs::Trigger>::SharedPtr m_statusService;
     rclcpp::Service<xsrvs::Trigger>::SharedPtr m_getReadyService;

--- a/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
+++ b/xsens_mtw_driver/include/xsens_mtw_driver/xsens_mtw_manager.hpp
@@ -11,6 +11,10 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
+// ROS2 messages
+#include "std_msgs/msg/int64.hpp"
+
+
 // Custom ROS2 messages
 #include "imu_msgs/msg/imu_data.hpp"
 #include "imu_msgs/msg/imu_data_array.hpp"
@@ -85,6 +89,7 @@ private:
     bool m_waitForConnections;
     bool m_keyInterrupt;
     bool m_isHeaderWritten;
+    bool m_syncSuccessful;
 
     // ROS2 Parameters
     std::string m_mtwTopicName;
@@ -95,6 +100,9 @@ private:
     bool m_imuResetOnRecord;
     bool m_useMagnetometer;
 
+    bool m_useSynchronisation;
+    std::string m_syncTopicName;
+
     // ROS2 Callbacks
     rclcpp::TimerBase::SharedPtr m_connectTimer;
     rclcpp::TimerBase::SharedPtr m_publishTimer;
@@ -102,7 +110,8 @@ private:
     // ROS2 Publisher
     rclcpp::Publisher<imu_msgs::msg::IMUDataArray>::SharedPtr m_imuPublisher;
     std::vector<rclcpp::Publisher<imu_msgs::msg::IMUDataSingle>::SharedPtr> m_imuPublishers;
-
+    rclcpp::Publisher<std_msgs::msg::Int64>::SharedPtr m_syncPublisher;
+    
     // ROS2 Services
     rclcpp::Service<xsrvs::Trigger>::SharedPtr m_statusService;
     rclcpp::Service<xsrvs::Trigger>::SharedPtr m_getReadyService;
@@ -133,6 +142,7 @@ private:
     void initialMasterSetup();
     void connectMTWsCallback();
     void completeInitialization();
+    void syncInitialization();
     void publishDataCallback();
     void checkRateSupport();
     void mtwSetup();

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -34,8 +34,7 @@ XsensManager::XsensManager(const std::string & name)
     this->declare_parameter("use_magnetometer", false);
     m_useMagnetometer = this->get_parameter("use_magnetometer").as_bool();
 
-    // TODO set to false by default
-    this->declare_parameter("use_synchronization", true);
+    this->declare_parameter("use_synchronization", false);
     m_useSynchronization = this->get_parameter("use_synchronization").as_bool();
 
     this->declare_parameter("synchronization_topic", "xsens_sync");

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -35,14 +35,14 @@ XsensManager::XsensManager(const std::string & name)
     m_useMagnetometer = this->get_parameter("use_magnetometer").as_bool();
 
     // TODO set to false by default
-    this->declare_parameter("use_synchronisation", true);
-    m_useSynchronisation = this->get_parameter("use_synchronisation").as_bool();
+    this->declare_parameter("use_synchronization", true);
+    m_usesynchronization = this->get_parameter("use_synchronization").as_bool();
 
-    this->declare_parameter("synchronisation_topic", "xsens_sync");
-    m_syncTopicName = this->get_parameter("synchronisation_topic").as_string();
+    this->declare_parameter("synchronization_topic", "xsens_sync");
+    m_syncTopicName = this->get_parameter("synchronization_topic").as_string();
 
-    this->declare_parameter("synchronisation_line", 2);
-    m_syncLine = this->get_parameter("synchronisation_line").as_int();
+    this->declare_parameter("synchronization_line", 2);
+    m_syncLine = this->get_parameter("synchronization_line").as_int();
 
     RCLCPP_INFO(this->get_logger(), "ROS2 parameters loaded:");
     RCLCPP_INFO(this->get_logger(), "- one_topic_per_imu: %s", m_oneTopicPerImu ? "true" : "false");
@@ -53,10 +53,10 @@ XsensManager::XsensManager(const std::string & name)
     RCLCPP_INFO(this->get_logger(), "- imu_reset_on_record: %s", m_imuResetOnRecord ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "- use_magnetometer: %s", m_useMagnetometer ? "true" : "false");
 
-    RCLCPP_INFO(this->get_logger(), "Synchronisation:");
-    RCLCPP_INFO(this->get_logger(), "  - use_synchronisation: %s", m_useSynchronisation ? "true" : "false");
+    RCLCPP_INFO(this->get_logger(), "synchronization:");
+    RCLCPP_INFO(this->get_logger(), "  - use_synchronization: %s", m_usesynchronization ? "true" : "false");
     RCLCPP_INFO(this->get_logger(), "  - topic_name: %s", m_syncTopicName.c_str());
-    RCLCPP_INFO(this->get_logger(), "  - synchronisation_line: %d", m_syncLine);
+    RCLCPP_INFO(this->get_logger(), "  - synchronization_line: %d", m_syncLine);
 
     // --------------------------------------------------------------------
     // ROS2 SERVICES
@@ -158,8 +158,8 @@ void XsensManager::initialMasterSetup()
         throw std::runtime_error(error.str());
     }
 
-    // Synchronisation
-    if (m_useSynchronisation){
+    // synchronization
+    if (m_usesynchronization){
         syncInitialization();
         if(m_syncSuccessful)
         {
@@ -341,10 +341,10 @@ void XsensManager::completeInitialization()
 
 }
 
-// Complete synchronisation_topic initialization steps
+// Complete synchronization_topic initialization steps
 void XsensManager::syncInitialization(){
     if(!m_wirelessMasterDevice->deviceId().isAwindaXStation()){
-        RCLCPP_ERROR(this->get_logger(), "Awinda XStation is required for synchronisation");
+        RCLCPP_ERROR(this->get_logger(), "Awinda XStation is required for synchronization");
         m_syncSuccessful = false;
         return;
     }
@@ -373,12 +373,12 @@ void XsensManager::syncInitialization(){
     syncSettings.push_back(syncSetting);
 
     if (!m_wirelessMasterDevice->setSyncSettings(syncSettings)) {
-        RCLCPP_ERROR(this->get_logger(), "Failed to configure the synchronisation");
+        RCLCPP_ERROR(this->get_logger(), "Failed to configure the synchronization");
         m_syncSuccessful = false;
         return;
     }
 
-    RCLCPP_INFO(this->get_logger(), "Synchronisation configured");
+    RCLCPP_INFO(this->get_logger(), "synchronization configured");
     m_syncSuccessful = true;
     return;
 
@@ -428,8 +428,8 @@ void XsensManager::publishDataCallback()
 
                 // Reset m_dataTracker if new data is available
                 m_dataTracker[i] = 0;
-            
-                // If synchronisation is needed
+
+                // If synchronization is needed
                 if(m_syncSuccessful){
                     XsTriggerIndicationData xtid = packet->triggerIndication(m_lineDateIdentifier);
                     if (xtid.m_timestamp > 0) {
@@ -440,7 +440,7 @@ void XsensManager::publishDataCallback()
                     }
                 }
             }
-            
+
             m_mtwCallbacks[i]->deleteOldestPacket();
         }
         else m_dataTracker[i]++;

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -162,7 +162,7 @@ void XsensManager::initialMasterSetup()
 
     // Synchronization
     if (m_useSynchronization){
-        RCLCPP_INFO(this->get_logger(), "Setting up synchronization...", m_syncLine);
+        RCLCPP_INFO(this->get_logger(), "Setting up synchronization on line: %d", m_syncLine);
         syncInitialization();
         if(m_syncSuccessful) m_syncPublisher = this->create_publisher<std_msgs::msg::Int64>(m_syncTopicName, 10);
     }

--- a/xsens_mtw_driver/src/xsens_mtw_manager.cpp
+++ b/xsens_mtw_driver/src/xsens_mtw_manager.cpp
@@ -359,7 +359,7 @@ void XsensManager::syncInitialization(){
     }
 
     XsSyncSetting syncSetting;
-    syncSetting.m_line = m_line;  // Use Sync_In1
+    syncSetting.m_line = m_line;  // Synchronization line determined by m_syncLine (1 or 2)
     syncSetting.m_function = XSF_TriggerIndication;  // Set function to trigger indication
     syncSetting.m_polarity = XSP_RisingEdge;  // Trigger on rising edge (change if needed)
     syncSetting.m_skipFactor = 0;  // No skipped triggers


### PR DESCRIPTION
# Description

The awinda base station has 2 Sync IN and 2 Sync Out BNC PORT.
The SDK also support synchronisation.
This PR add support for basic synchronisation.

Fixes #7 

# Changes 

- Adding Parameters
  - To enable the synchronisation
  - To set the name of the synchronisation topic
  - To set the synchronisation line (1 or 2)
- Creating a topic to publish the timestamp of synchronisation  (when sync is enabled)
- Configuring MasterDevice to configure synchronisation (when sync is enabled)
- Publishing messages on the topics when a rising edege is detected on the selected line (when sync is enabled)

# Tests

Tested with the awinda base station and a signal generator. 

The frequency of the messages on the topic matched the frequency of the sync signal with low std. 